### PR TITLE
Set libvpx-vp9 as default

### DIFF
--- a/build/webm.lua
+++ b/build/webm.lua
@@ -31,7 +31,7 @@ local options = {
   strict_bitrate_multiplier = 0.95,
   -- In kilobits.
   strict_audio_bitrate = 64,
-  video_codec = "libvpx",
+  video_codec = "libvpx-vp9",
   audio_codec = "libvorbis",
   twopass = true,
   -- Set the number of encoding threads, for codecs libvpx and libvpx-vp9

--- a/src/options.moon
+++ b/src/options.moon
@@ -25,7 +25,7 @@ options =
 	strict_bitrate_multiplier: 0.95
 	-- In kilobits.
 	strict_audio_bitrate: 64
-	video_codec: "libvpx"
+	video_codec: "libvpx-vp9"
 	audio_codec: "libvorbis"
 	twopass: true
 	-- Set the number of encoding threads, for codecs libvpx and libvpx-vp9


### PR DESCRIPTION
Fixes the ffmpeg corruption from issue #2 