### PR TITLE
ffmpeg support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ all: $(OUTPUT)
 
 $(OUTPUT): $(JOINEDSRC)
 	@printf 'Building %s\n' $@
-	@moonc -o $@ $<
+	@moonc -o $@ $< 2>/dev/null
 
 $(JOINEDSRC): $(SOURCES) | $(TMPDIR)
 	@printf 'Generating %s\n' $@

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,9 @@ SOURCES += src/video_to_screen.moon
 SOURCES += src/formats/base.moon
 SOURCES += src/formats/rawvideo.moon
 SOURCES += src/formats/webm.moon
+SOURCES += src/backends/base.moon
+SOURCES += src/backends/mpv.moon
+SOURCES += src/backends/ffmpeg.moon
 SOURCES += src/encode.moon
 SOURCES += src/Page.moon
 SOURCES += src/CropPage.moon
@@ -25,7 +28,7 @@ all: $(OUTPUT)
 
 $(OUTPUT): $(JOINEDSRC)
 	@printf 'Building %s\n' $@
-	@moonc -o $@ $< 2>/dev/null
+	@moonc -o $@ $<
 
 $(JOINEDSRC): $(SOURCES) | $(TMPDIR)
 	@printf 'Generating %s\n' $@

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ SOURCES := src/requires.moon
 SOURCES += src/options.moon
 SOURCES += src/util.moon
 SOURCES += src/video_to_screen.moon
+SOURCES += src/encoding_parameters.moon
 SOURCES += src/formats/base.moon
 SOURCES += src/formats/rawvideo.moon
 SOURCES += src/formats/webm.moon

--- a/build/webm.lua
+++ b/build/webm.lua
@@ -475,12 +475,12 @@ do
       if params == nil then
         params = { }
       end
+      self.lavfiCompat = not self.__class.isBuiltin(name)
       if string.sub(name, 1, 6) == "lavfi-" then
         self.name = string.sub(name, 7, string.len(name))
       else
         self.name = name
       end
-      self.lavfiCompat = not self.__class:isBuiltin(name)
       self.params = params
     end,
     __base = _base_0,
@@ -666,7 +666,8 @@ do
       if colormatrixFilter[colormatrix] then
         append(ret, {
           MpvFilter("lavfi-colormatrix", {
-            ["@0"] = tostring(colormatrixFilter[colormatrix]),
+            ["@0"] = colormatrixFilter[colormatrix]
+          }, {
             ["@1"] = "bt601"
           })
         })

--- a/build/webm.lua
+++ b/build/webm.lua
@@ -5,11 +5,11 @@ local utils = require("mp.utils")
 local mpopts = require("mp.options")
 local options = {
   -- Defaults to shift+w
-  keybind = "W"
+  keybind = "W",
   -- If empty, saves on the same directory of the playing video.
   -- A starting "~" will be replaced by the home dir.
-  output_directory = ""
-  run_detached = false
+  output_directory = "",
+  run_detached = false,
   -- Template string for the output file
   -- %f - Filename, with extension
   -- %F - Filename, without extension
@@ -17,39 +17,39 @@ local options = {
   -- %s, %e - Start and end time, with milliseconds
   -- %S, %E - Start and time, without milliseconds
   -- %M - "-audio", if audio is enabled, empty otherwise
-  output_template = "%F-[%s-%e]%M"
+  output_template = "%F-[%s-%e]%M",
   -- Scale video to a certain height, keeping the aspect ratio. -1 disables it.
-  scale_height = -1
+  scale_height = -1,
   -- Target filesize, in kB.
-  target_filesize = 2500
+  target_filesize = 2500,
   -- If true, will use stricter flags to ensure the resulting file doesn't
   -- overshoot the target filesize. Not recommended, as constrained quality
   -- mode should work well, unless you're really having trouble hitting
   -- the target size.
-  strict_filesize_constraint = false
-  strict_bitrate_multiplier = 0.95
+  strict_filesize_constraint = false,
+  strict_bitrate_multiplier = 0.95,
   -- In kilobits.
-  strict_audio_bitrate = 64
+  strict_audio_bitrate = 64,
   -- Sets the output format, from a few predefined ones.
   -- Currently we have webm-vp8 (libvpx/libvorbis), webm-vp9 (libvpx-vp9/libvorbis)
   -- and raw (rawvideo/pcm_s16le).
-  output_format = "webm-vp8"
+  output_format = "webm-vp8",
   -- The encoding backend to use. Currently supports mpv and ffmpeg.
-  backend = "mpv"
+  backend = "mpv",
   -- Location to the backend executable. Leave blank to have this fall back on the backend option.
-  backend_location = ""
-  twopass = false
+  backend_location = "",
+  twopass = false,
   -- If set, applies the video filters currently used on the playback to the encode.
-  apply_current_filters = true
+  apply_current_filters = true,
   -- Set the number of encoding threads, for codecs libvpx and libvpx-vp9
-  libvpx_threads = 4
-  additional_flags = ""
+  libvpx_threads = 4,
+  additional_flags = "",
   -- Useful for flags that may impact output filesize, such as crf, qmin, qmax etc
   -- Won't be applied when strict_filesize_constraint is on.
-  non_strict_additional_flags = "--ovcopts-add=crf=10"
+  non_strict_additional_flags = "--ovcopts-add=crf=10",
   -- The font size used in the menu. Isn't used for the notifications (started encode, finished encode etc)
-  font_size = 28
-  margin = 10
+  font_size = 28,
+  margin = 10,
   message_duration = 5
 }
 mpopts.read_options(options)

--- a/build/webm.lua
+++ b/build/webm.lua
@@ -1149,8 +1149,6 @@ do
     end
   })
   _base_0.__class = _class_0
-  local self = _class_0
-  local _ = solve
   if _parent_0.__inherited then
     _parent_0.__inherited(_parent_0, _class_0)
   end

--- a/build/webm.lua
+++ b/build/webm.lua
@@ -141,10 +141,10 @@ calculate_scale_factor = function()
 end
 local get_backend_location
 get_backend_location = function()
-  if options.backend_location then
-    return options.backend_location
+  if not options.backend_location or string.len(options.backend_location) == 0 then
+    return options.backend
   end
-  return options.backend
+  return options.backend_location
 end
 local dimensions_changed = true
 local _video_dimensions = { }
@@ -413,6 +413,100 @@ make_fullscreen_region = function()
   b:set_from_screen(xb, yb)
   r:set_from_points(a, b)
   return r
+end
+local Track
+do
+  local _class_0
+  local _base_0 = { }
+  _base_0.__index = _base_0
+  _class_0 = setmetatable({
+    __init = function(self, id, index, type)
+      self.id = id
+      self.index = index
+      self.type = type
+    end,
+    __base = _base_0,
+    __name = "Track"
+  }, {
+    __index = _base_0,
+    __call = function(cls, ...)
+      local _self_0 = setmetatable({}, _base_0)
+      cls.__init(_self_0, ...)
+      return _self_0
+    end
+  })
+  _base_0.__class = _class_0
+  Track = _class_0
+end
+local MpvFilter
+do
+  local _class_0
+  local _base_0 = { }
+  _base_0.__index = _base_0
+  _class_0 = setmetatable({
+    __init = function(self, name, params)
+      if params == nil then
+        params = { }
+      end
+      if string.sub(name, 1, 6) == "lavfi-" then
+        self.name = string.sub(name, 7, string.len(name))
+        self.lavfiCompat = true
+      else
+        self.name = name
+        self.lavfiCompat = false
+      end
+      self.params = params
+    end,
+    __base = _base_0,
+    __name = "MpvFilter"
+  }, {
+    __index = _base_0,
+    __call = function(cls, ...)
+      local _self_0 = setmetatable({}, _base_0)
+      cls.__init(_self_0, ...)
+      return _self_0
+    end
+  })
+  _base_0.__class = _class_0
+  MpvFilter = _class_0
+end
+local EncodingParameters
+do
+  local _class_0
+  local _base_0 = { }
+  _base_0.__index = _base_0
+  _class_0 = setmetatable({
+    __init = function(self)
+      self.format = nil
+      self.inputPath = nil
+      self.outputPath = nil
+      self.startTime = 0
+      self.endTime = 0
+      self.crop = nil
+      self.scale = nil
+      self.videoTrack = nil
+      self.audioTrack = nil
+      self.subTrack = nil
+      self.bitrate = 0
+      self.minBitrate = 0
+      self.maxBitrate = 0
+      self.audioBitrate = 0
+      self.twopass = false
+      self.mpvFilters = { }
+      self.flags = { }
+    end,
+    __base = _base_0,
+    __name = "EncodingParameters"
+  }, {
+    __index = _base_0,
+    __call = function(cls, ...)
+      local _self_0 = setmetatable({}, _base_0)
+      cls.__init(_self_0, ...)
+      return _self_0
+    end
+  })
+  _base_0.__class = _class_0
+  EncodingParameters = _class_0
 end
 local formats = { }
 local Format
@@ -760,7 +854,7 @@ do
     buildCommand = function(self, params)
       local format = params.format
       local command = {
-        options.encoder_location,
+        get_backend_location(),
         params.inputPath,
         "--start=" .. seconds_to_time_string(params.startTime, false, true),
         "--end=" .. seconds_to_time_string(params.endTime, false, true),
@@ -910,7 +1004,7 @@ do
     buildCommand = function(self, params)
       local format = params.format
       local command = {
-        options.encoder_location,
+        get_backend_location(),
         "-y",
         "-ss",
         seconds_to_time_string(params.startTime, false, true),
@@ -1063,100 +1157,6 @@ do
   FfmpegBackend = _class_0
 end
 backends["ffmpeg"] = FfmpegBackend()
-local Track
-do
-  local _class_0
-  local _base_0 = { }
-  _base_0.__index = _base_0
-  _class_0 = setmetatable({
-    __init = function(self, id, index, type)
-      self.id = id
-      self.index = index
-      self.type = type
-    end,
-    __base = _base_0,
-    __name = "Track"
-  }, {
-    __index = _base_0,
-    __call = function(cls, ...)
-      local _self_0 = setmetatable({}, _base_0)
-      cls.__init(_self_0, ...)
-      return _self_0
-    end
-  })
-  _base_0.__class = _class_0
-  Track = _class_0
-end
-local MpvFilter
-do
-  local _class_0
-  local _base_0 = { }
-  _base_0.__index = _base_0
-  _class_0 = setmetatable({
-    __init = function(self, name, params)
-      if params == nil then
-        params = { }
-      end
-      if string.sub(name, 1, 6) == "lavfi-" then
-        self.name = string.sub(name, 7, string.len(name))
-        self.lavfiCompat = true
-      else
-        self.name = name
-        self.lavfiCompat = false
-      end
-      self.params = params
-    end,
-    __base = _base_0,
-    __name = "MpvFilter"
-  }, {
-    __index = _base_0,
-    __call = function(cls, ...)
-      local _self_0 = setmetatable({}, _base_0)
-      cls.__init(_self_0, ...)
-      return _self_0
-    end
-  })
-  _base_0.__class = _class_0
-  MpvFilter = _class_0
-end
-local EncodingParameters
-do
-  local _class_0
-  local _base_0 = { }
-  _base_0.__index = _base_0
-  _class_0 = setmetatable({
-    __init = function(self)
-      self.format = nil
-      self.inputPath = nil
-      self.outputPath = nil
-      self.startTime = 0
-      self.endTime = 0
-      self.crop = nil
-      self.scale = nil
-      self.videoTrack = nil
-      self.audioTrack = nil
-      self.subTrack = nil
-      self.bitrate = 0
-      self.minBitrate = 0
-      self.maxBitrate = 0
-      self.audioBitrate = 0
-      self.twopass = false
-      self.mpvFilters = { }
-      self.flags = { }
-    end,
-    __base = _base_0,
-    __name = "EncodingParameters"
-  }, {
-    __index = _base_0,
-    __call = function(cls, ...)
-      local _self_0 = setmetatable({}, _base_0)
-      cls.__init(_self_0, ...)
-      return _self_0
-    end
-  })
-  _base_0.__class = _class_0
-  EncodingParameters = _class_0
-end
 local get_active_tracks
 get_active_tracks = function()
   local accepted = {
@@ -1201,7 +1201,7 @@ get_current_filters = function()
 end
 local encode
 encode = function(region, startTime, endTime)
-  local backend = backends[options.encoder]
+  local backend = backends[options.backend]
   local format = formats[options.output_format]
   local params = EncodingParameters()
   params.format = format
@@ -1285,7 +1285,7 @@ encode = function(region, startTime, endTime)
     message("Started encode... (" .. tostring(backend.name) .. ")")
     local res = backend:encode(params)
     if res then
-      return message("Encoded successfully! Saved to\\N" .. tostring(bold(res)))
+      return message("Encoded successfully! Saved to\\N" .. tostring(bold(params.outputPath)))
     else
       return message("Encode failed! Check the logs for details.")
     end

--- a/build/webm.lua
+++ b/build/webm.lua
@@ -4,46 +4,24 @@ local msg = require("mp.msg")
 local utils = require("mp.utils")
 local mpopts = require("mp.options")
 local options = {
-  -- Defaults to shift+w
   keybind = "W",
-  -- If empty, saves on the same directory of the playing video.
-  -- A starting "~" will be replaced by the home dir.
   output_directory = "",
   run_detached = false,
-  -- Template string for the output file
-  -- %f - Filename, with extension
-  -- %F - Filename, without extension
-  -- %T - Media title, if it exists, or filename, with extension (useful for some streams, such as YouTube).
-  -- %s, %e - Start and end time, with milliseconds
-  -- %S, %E - Start and time, without milliseconds
-  -- %M - "-audio", if audio is enabled, empty otherwise
   output_template = "%F-[%s-%e]%M",
-  -- Scale video to a certain height, keeping the aspect ratio. -1 disables it.
   scale_height = -1,
-  -- Target filesize, in kB.
-  target_filesize = 2500,
-  -- If true, will use stricter flags to ensure the resulting file doesn't
-  -- overshoot the target filesize. Not recommended, as constrained quality
-  -- mode should work well, unless you're really having trouble hitting
-  -- the target size.
+  target_filesize = 0,
   strict_filesize_constraint = false,
   strict_bitrate_multiplier = 0.95,
-  -- In kilobits.
   strict_audio_bitrate = 64,
-  -- Sets the output format, from a few predefined ones.
-  -- Currently we have webm-vp8 (libvpx/libvorbis), webm-vp9 (libvpx-vp9/libvorbis)
-  -- and raw (rawvideo/pcm_s16le).
   output_format = "webm-vp8",
+  encoder = "ffmpeg",
+  encoder_location = "ffmpeg",
   twopass = false,
-  -- If set, applies the video filters currently used on the playback to the encode.
   apply_current_filters = true,
-  -- Set the number of encoding threads, for codecs libvpx and libvpx-vp9
   libvpx_threads = 4,
+  libx264_preset = "veryfast",
   additional_flags = "",
-  -- Useful for flags that may impact output filesize, such as crf, qmin, qmax etc
-  -- Won't be applied when strict_filesize_constraint is on.
-  non_strict_additional_flags = "--ovcopts-add=crf=10",
-  -- The font size used in the menu. Isn't used for the notifications (started encode, finished encode etc)
+  non_strict_additional_flags = "",
   font_size = 28,
   margin = 10,
   message_duration = 5
@@ -290,9 +268,39 @@ clamp_point = function(top_left, point, bottom_right)
     y = clamp(top_left.y, point.y, bottom_right.y)
   }
 end
+local Point
+do
+  local _class_0
+  local _base_0 = { }
+  _base_0.__index = _base_0
+  _class_0 = setmetatable({
+    __init = function(self, x, y)
+      if x == nil then
+        x = -1
+      end
+      if y == nil then
+        y = -1
+      end
+      self.x = x
+      self.y = y
+    end,
+    __base = _base_0,
+    __name = "Point"
+  }, {
+    __index = _base_0,
+    __call = function(cls, ...)
+      local _self_0 = setmetatable({}, _base_0)
+      cls.__init(_self_0, ...)
+      return _self_0
+    end
+  })
+  _base_0.__class = _class_0
+  Point = _class_0
+end
 local VideoPoint
 do
   local _class_0
+  local _parent_0 = Point
   local _base_0 = {
     set_from_screen = function(self, sx, sy)
       local d = get_video_dimensions()
@@ -312,15 +320,26 @@ do
     end
   }
   _base_0.__index = _base_0
+  setmetatable(_base_0, _parent_0.__base)
   _class_0 = setmetatable({
-    __init = function(self)
-      self.x = -1
-      self.y = -1
+    __init = function(self, ...)
+      return _class_0.__parent.__init(self, ...)
     end,
     __base = _base_0,
-    __name = "VideoPoint"
+    __name = "VideoPoint",
+    __parent = _parent_0
   }, {
-    __index = _base_0,
+    __index = function(cls, name)
+      local val = rawget(_base_0, name)
+      if val == nil then
+        local parent = rawget(cls, "__parent")
+        if parent then
+          return parent[name]
+        end
+      else
+        return val
+      end
+    end,
     __call = function(cls, ...)
       local _self_0 = setmetatable({}, _base_0)
       cls.__init(_self_0, ...)
@@ -328,6 +347,9 @@ do
     end
   })
   _base_0.__class = _class_0
+  if _parent_0.__inherited then
+    _parent_0.__inherited(_parent_0, _class_0)
+  end
   VideoPoint = _class_0
 end
 local Region
@@ -386,18 +408,112 @@ make_fullscreen_region = function()
   r:set_from_points(a, b)
   return r
 end
+local Track
+do
+  local _class_0
+  local _base_0 = { }
+  _base_0.__index = _base_0
+  _class_0 = setmetatable({
+    __init = function(self, id, index, type)
+      self.id = id
+      self.index = index
+      self.type = type
+    end,
+    __base = _base_0,
+    __name = "Track"
+  }, {
+    __index = _base_0,
+    __call = function(cls, ...)
+      local _self_0 = setmetatable({}, _base_0)
+      cls.__init(_self_0, ...)
+      return _self_0
+    end
+  })
+  _base_0.__class = _class_0
+  Track = _class_0
+end
+local MpvFilter
+do
+  local _class_0
+  local _base_0 = { }
+  _base_0.__index = _base_0
+  _class_0 = setmetatable({
+    __init = function(self, name, params)
+      if params == nil then
+        params = { }
+      end
+      if string.sub(name, 1, 6) == "lavfi-" then
+        self.name = string.sub(name, 7, string.len(name))
+        self.lavfiCompat = true
+      else
+        self.name = name
+        self.lavfiCompat = false
+      end
+      self.params = params
+    end,
+    __base = _base_0,
+    __name = "MpvFilter"
+  }, {
+    __index = _base_0,
+    __call = function(cls, ...)
+      local _self_0 = setmetatable({}, _base_0)
+      cls.__init(_self_0, ...)
+      return _self_0
+    end
+  })
+  _base_0.__class = _class_0
+  MpvFilter = _class_0
+end
+local EncodingParameters
+do
+  local _class_0
+  local _base_0 = { }
+  _base_0.__index = _base_0
+  _class_0 = setmetatable({
+    __init = function(self)
+      self.format = nil
+      self.inputPath = nil
+      self.outputPath = nil
+      self.startTime = 0
+      self.endTime = 0
+      self.crop = nil
+      self.scale = nil
+      self.videoTrack = nil
+      self.audioTrack = nil
+      self.subTrack = nil
+      self.bitrate = 0
+      self.minBitrate = 0
+      self.maxBitrate = 0
+      self.audioBitrate = 0
+      self.twopass = false
+      self.mpvFilters = { }
+      self.flags = { }
+    end,
+    __base = _base_0,
+    __name = "EncodingParameters"
+  }, {
+    __index = _base_0,
+    __call = function(cls, ...)
+      local _self_0 = setmetatable({}, _base_0)
+      cls.__init(_self_0, ...)
+      return _self_0
+    end
+  })
+  _base_0.__class = _class_0
+  EncodingParameters = _class_0
+end
 local formats = { }
 local Format
 do
   local _class_0
   local _base_0 = {
-    getPreFilters = function(self)
+    getPreFilters = function(self, backend)
       return { }
     end,
-    getPostFilters = function(self)
+    getPostFilters = function(self, backend)
       return { }
     end,
-    getFlags = function(self)
+    getFlags = function(self, backend)
       return { }
     end
   }
@@ -445,11 +561,17 @@ do
         return "bt601"
       end
     end,
-    getPostFilters = function(self)
+    getPostFilters = function(self, backend)
       return {
-        "format=yuv444p16",
-        "lavfi-scale=in_color_matrix=" .. self:getColorspace(),
-        "format=bgr24"
+        MpvFilter("format", {
+          "yuv444p16"
+        }),
+        MpvFilter("lavfi-scale", {
+          ["in_color_matrix"] = self:getColorspace()
+        }),
+        MpvFilter("format", {
+          "bgr24"
+        })
       }
     end
   }
@@ -497,7 +619,7 @@ do
   local _class_0
   local _parent_0 = Format
   local _base_0 = {
-    getPreFilters = function(self)
+    getPreFilters = function(self, backend)
       local colormatrixFilter = {
         ["bt.709"] = "bt709",
         ["bt.2020"] = "bt2020",
@@ -507,15 +629,26 @@ do
       local colormatrix = mp.get_property_native("video-params/colormatrix")
       if colormatrixFilter[colormatrix] then
         append(ret, {
-          "lavfi-colormatrix=" .. tostring(colormatrixFilter[colormatrix]) .. ":bt601"
+          MpvFilter("lavfi-colormatrix", {
+            ["@0"] = tostring(colormatrixFilter[colormatrix]),
+            ["@1"] = "bt601"
+          })
         })
       end
       return ret
     end,
-    getFlags = function(self)
-      return {
-        "--ovcopts-add=threads=" .. tostring(options.libvpx_threads)
-      }
+    getFlags = function(self, backend)
+      local _exp_0 = backend.name
+      if "mpv" == _exp_0 then
+        return {
+          "--ovcopts-add=threads=" .. tostring(options.libvpx_threads)
+        }
+      elseif "ffmpeg" == _exp_0 then
+        return {
+          "-threads",
+          options.libvpx_threads
+        }
+      end
     end
   }
   _base_0.__index = _base_0
@@ -562,10 +695,18 @@ do
   local _class_0
   local _parent_0 = Format
   local _base_0 = {
-    getFlags = function(self)
-      return {
-        "--ovcopts-add=threads=" .. tostring(options.libvpx_threads)
-      }
+    getFlags = function(self, backend)
+      local _exp_0 = backend.name
+      if "mpv" == _exp_0 then
+        return {
+          "--ovcopts-add=threads=" .. tostring(options.libvpx_threads)
+        }
+      elseif "ffmpeg" == _exp_0 then
+        return {
+          "-threads",
+          options.libvpx_threads
+        }
+      end
     end
   }
   _base_0.__index = _base_0
@@ -607,6 +748,464 @@ do
   WebmVP9 = _class_0
 end
 formats["webm-vp9"] = WebmVP9()
+local H264
+do
+  local _class_0
+  local _parent_0 = Format
+  local _base_0 = {
+    getPostFilters = function(self, backend)
+      return {
+        "format=yuv420p"
+      }
+    end,
+    getFlags = function(self, backend)
+      return {
+        "--ovcopts-add=preset=" .. tostring(options.libx264_preset)
+      }
+    end
+  }
+  _base_0.__index = _base_0
+  setmetatable(_base_0, _parent_0.__base)
+  _class_0 = setmetatable({
+    __init = function(self)
+      self.displayName = "H.264"
+      self.supportsTwopass = true
+      self.videoCodec = "libx264"
+      self.audioCodec = "aac"
+      self.outputExtension = "mp4"
+      self.acceptsBitrate = true
+    end,
+    __base = _base_0,
+    __name = "H264",
+    __parent = _parent_0
+  }, {
+    __index = function(cls, name)
+      local val = rawget(_base_0, name)
+      if val == nil then
+        local parent = rawget(cls, "__parent")
+        if parent then
+          return parent[name]
+        end
+      else
+        return val
+      end
+    end,
+    __call = function(cls, ...)
+      local _self_0 = setmetatable({}, _base_0)
+      cls.__init(_self_0, ...)
+      return _self_0
+    end
+  })
+  _base_0.__class = _class_0
+  if _parent_0.__inherited then
+    _parent_0.__inherited(_parent_0, _class_0)
+  end
+  H264 = _class_0
+end
+formats["hevc-h264"] = H264()
+local backends = { }
+local Backend
+do
+  local _class_0
+  local _base_0 = {
+    encode = function(self, params)
+      msg.verbose("Building command from params: ", utils.to_string(params))
+      local command = self:buildCommand(params)
+      if command then
+        msg.info("Encoding to", params.outputPath)
+        msg.verbose("Command line:", table.concat(command, " "))
+        return run_subprocess({
+          args = command,
+          cancellable = false
+        })
+      end
+      return false
+    end,
+    encodeDetached = function(self, params)
+      local command = self:buildCommand(params)
+      if command then
+        msg.info("Encoding to", params.outputPath)
+        msg.verbose("Command line:", table.concat(command, " "))
+        utils.subprocess_detached({
+          args = command
+        })
+        return true
+      end
+      return false
+    end,
+    buildCommand = function(self, params)
+      return nil
+    end
+  }
+  _base_0.__index = _base_0
+  _class_0 = setmetatable({
+    __init = function(self)
+      self.name = "No backend"
+    end,
+    __base = _base_0,
+    __name = "Backend"
+  }, {
+    __index = _base_0,
+    __call = function(cls, ...)
+      local _self_0 = setmetatable({}, _base_0)
+      cls.__init(_self_0, ...)
+      return _self_0
+    end
+  })
+  _base_0.__class = _class_0
+  Backend = _class_0
+end
+local MpvBackend
+do
+  local _class_0
+  local _parent_0 = Backend
+  local _base_0 = {
+    appendProperty = function(self, out, property_name, option_name)
+      option_name = option_name or property_name
+      local prop = mp.get_property(property_name)
+      if prop and prop ~= "" then
+        return append(out, {
+          "--" .. tostring(option_name) .. "=" .. tostring(prop)
+        })
+      end
+    end,
+    getPlaybackOptions = function(self)
+      local ret = { }
+      self:appendProperty(ret, "sub-ass-override")
+      self:appendProperty(ret, "sub-ass-force-style")
+      self:appendProperty(ret, "sub-auto")
+      for _, track in ipairs(mp.get_property_native("track-list")) do
+        if track["type"] == "sub" and track["external"] then
+          append(ret, {
+            "--sub-files-append=" .. tostring(track['external-filename'])
+          })
+        end
+      end
+      return ret
+    end,
+    solveFilters = function(self, filters)
+      local solved = { }
+      for _index_0 = 1, #filters do
+        local filter = filters[_index_0]
+        local str = filter.lavfiCompat and "lavfi-" or ""
+        str = str .. (filter.name .. "=")
+        for k, v in pairs(filter.params) do
+          if tonumber(k) == nil then
+            str = str .. tostring(k) .. "=%" .. tostring(string.len(v)) .. "%" .. tostring(v) .. ":"
+          else
+            str = str .. tostring(v) .. ":"
+          end
+        end
+        solved[#solved + 1] = string.sub(str, 0, string.len(str) - 1)
+      end
+      return solved
+    end,
+    buildCommand = function(self, params)
+      local format = params.format
+      local command = {
+        options.encoder_location,
+        params.inputPath,
+        "--start=" .. seconds_to_time_string(params.startTime, false, true),
+        "--end=" .. seconds_to_time_string(params.endTime, false, true),
+        "--ovc=" .. tostring(format.videoCodec),
+        "--oac=" .. tostring(format.audioCodec),
+        "--loop-file=no"
+      }
+      append(command, {
+        "--vid=" .. (params.videoTrack ~= nil and tostring(params.videoTrack.id) or "no"),
+        "--aid=" .. (params.audioTrack ~= nil and tostring(params.audioTrack.id) or "no"),
+        "--sid=" .. (params.subTrackId ~= nil and tostring(params.subTrack.id) or "no")
+      })
+      append(command, self:getPlaybackOptions())
+      local filters = { }
+      append(filters, self:solveFilters(format:getPreFilters(self)))
+      append(filters, self:solveFilters(params.mpvFilters))
+      if params.crop then
+        filters[#filters + 1] = "lavfi-crop=" .. tostring(params.crop.w) .. ":" .. tostring(params.crop.h) .. ":" .. tostring(params.crop.x) .. ":" .. tostring(params.crop.y)
+      end
+      if params.scale then
+        filters[#filters + 1] = "lavfi-scale=" .. tostring(params.scale.x) .. ":" .. tostring(params.scale.y)
+      end
+      append(filters, self:solveFilters(format:getPostFilters(self)))
+      for _index_0 = 1, #filters do
+        local f = filters[_index_0]
+        command[#command + 1] = "--vf-add=" .. tostring(f)
+      end
+      append(command, format:getFlags(self))
+      if format.acceptsBitrate then
+        if params.audioBitrate ~= 0 then
+          command[#command + 1] = "--oacopts-add=b=" .. tostring(params.audioBitrate) .. "k"
+        end
+        if params.bitrate ~= 0 then
+          command[#command + 1] = "--ovcopts-add=b=" .. tostring(params.bitrate) .. "k"
+        end
+        if params.minBitrate ~= 0 then
+          command[#command + 1] = "--ovcopts-add=minrate=" .. tostring(params.bitrate) .. "k"
+        end
+        if params.maxBitrate ~= 0 then
+          command[#command + 1] = "--ovcopts-add=maxrate=" .. tostring(params.bitrate) .. "k"
+        end
+      end
+      local _list_0 = params.flags
+      for _index_0 = 1, #_list_0 do
+        local flag = _list_0[_index_0]
+        command[#command + 1] = flag
+      end
+      if params.twopass and format.supportsTwopass then
+        local first_pass_cmdline
+        do
+          local _accum_0 = { }
+          local _len_0 = 1
+          for _index_0 = 1, #command do
+            local arg = command[_index_0]
+            _accum_0[_len_0] = arg
+            _len_0 = _len_0 + 1
+          end
+          first_pass_cmdline = _accum_0
+        end
+        append(first_pass_cmdline, {
+          "--ovcopts-add=flags=+pass1",
+          "-of=" .. tostring(format.outputExtension),
+          "-o=" .. tostring(get_null_path())
+        })
+        message("Starting first pass...")
+        msg.verbose("First-pass command line: ", table.concat(first_pass_cmdline, " "))
+        local res = run_subprocess({
+          args = first_pass_cmdline,
+          cancellable = false
+        })
+        if not res then
+          message("First pass failed! Check the logs for details.")
+          return nil
+        end
+        append(command, {
+          "--ovcopts-add=flags=+pass2"
+        })
+      end
+      append(command, {
+        "-o=" .. tostring(params.outputPath)
+      })
+      return command
+    end
+  }
+  _base_0.__index = _base_0
+  setmetatable(_base_0, _parent_0.__base)
+  _class_0 = setmetatable({
+    __init = function(self)
+      self.name = "mpv"
+    end,
+    __base = _base_0,
+    __name = "MpvBackend",
+    __parent = _parent_0
+  }, {
+    __index = function(cls, name)
+      local val = rawget(_base_0, name)
+      if val == nil then
+        local parent = rawget(cls, "__parent")
+        if parent then
+          return parent[name]
+        end
+      else
+        return val
+      end
+    end,
+    __call = function(cls, ...)
+      local _self_0 = setmetatable({}, _base_0)
+      cls.__init(_self_0, ...)
+      return _self_0
+    end
+  })
+  _base_0.__class = _class_0
+  if _parent_0.__inherited then
+    _parent_0.__inherited(_parent_0, _class_0)
+  end
+  MpvBackend = _class_0
+end
+backends["mpv"] = MpvBackend()
+local FfmpegBackend
+do
+  local _class_0
+  local _parent_0 = Backend
+  local _base_0 = {
+    solveFilters = function(self, filters)
+      local solved = { }
+      for _index_0 = 1, #filters do
+        local _continue_0 = false
+        repeat
+          local filter = filters[_index_0]
+          if not filter.lavfiCompat then
+            _continue_0 = true
+            break
+          end
+          local str = filter.name .. "="
+          for k, v in pairs(filter.params) do
+            str = str .. tostring(v) .. ":"
+          end
+          solved[#solved + 1] = string.sub(str, 0, string.len(str) - 1)
+          _continue_0 = true
+        until true
+        if not _continue_0 then
+          break
+        end
+      end
+      return solved
+    end,
+    buildCommand = function(self, params)
+      local format = params.format
+      local command = {
+        options.encoder_location,
+        "-y",
+        "-ss",
+        seconds_to_time_string(params.startTime, false, true),
+        "-i",
+        params.inputPath,
+        "-t",
+        tostring(params.endTime - params.startTime)
+      }
+      if params.videoTrack ~= nil and params.videoTrack.index ~= nil then
+        append(command, {
+          "-map",
+          "0:" .. tostring(params.videoTrack.index)
+        })
+      end
+      if params.audioTrack ~= nil and params.audioTrack.index ~= nil then
+        append(command, {
+          "-map",
+          "0:" .. tostring(params.audioTrack.index)
+        })
+      end
+      if params.subTrack ~= nil and params.subTrack.index ~= nil then
+        append(command, {
+          "-map",
+          "0:" .. tostring(params.subTrack.index)
+        })
+      end
+      append(command, {
+        "-c:v",
+        tostring(format.videoCodec),
+        "-c:a",
+        tostring(format.audioCodec)
+      })
+      local filters = { }
+      append(filters, self:solveFilters(format:getPreFilters(self)))
+      append(filters, self:solveFilters(params.mpvFilters))
+      if params.crop then
+        filters[#filters + 1] = "crop=" .. tostring(params.crop.w) .. ":" .. tostring(params.crop.h) .. ":" .. tostring(params.crop.x) .. ":" .. tostring(params.crop.y)
+      end
+      if params.scale then
+        filters[#filters + 1] = "scale=" .. tostring(params.scale.x) .. ":" .. tostring(params.scale.y)
+      end
+      append(filters, self:solveFilters(format:getPostFilters(self)))
+      append(command, {
+        "-vf",
+        table.concat(filters, ",")
+      })
+      append(command, format:getFlags(self))
+      if format.acceptsBitrate then
+        if params.audioBitrate ~= 0 then
+          append(command, {
+            "-b:a",
+            tostring(params.audioBitrate) .. "K"
+          })
+        end
+        if params.bitrate ~= 0 then
+          append(command, {
+            "-b:v",
+            tostring(params.bitrate) .. "K"
+          })
+        end
+        if params.minBitrate ~= 0 then
+          append(command, {
+            "-minrate",
+            tostring(params.minBitrate) .. "K"
+          })
+        end
+        if params.maxBitrate ~= 0 then
+          append(command, {
+            "-maxrate",
+            tostring(params.maxBitrate) .. "K"
+          })
+        end
+      end
+      local _list_0 = params.flags
+      for _index_0 = 1, #_list_0 do
+        local flag = _list_0[_index_0]
+        command[#command + 1] = flag
+      end
+      if params.twopass and format.supportsTwopass then
+        local first_pass_cmdline
+        do
+          local _accum_0 = { }
+          local _len_0 = 1
+          for _index_0 = 1, #command do
+            local arg = command[_index_0]
+            _accum_0[_len_0] = arg
+            _len_0 = _len_0 + 1
+          end
+          first_pass_cmdline = _accum_0
+        end
+        append(first_pass_cmdline, {
+          "-pass",
+          "1",
+          get_null_path()
+        })
+        message("Starting first pass...")
+        msg.verbose("First-pass command line: ", table.concat(first_pass_cmdline, " "))
+        local res = run_subprocess({
+          args = first_pass_cmdline,
+          cancellable = false
+        })
+        if not res then
+          message("First pass failed! Check the logs for details.")
+          return nil
+        end
+        append(command, {
+          "-pass",
+          "2"
+        })
+      end
+      append(command, {
+        params.outputPath
+      })
+      return command
+    end
+  }
+  _base_0.__index = _base_0
+  setmetatable(_base_0, _parent_0.__base)
+  _class_0 = setmetatable({
+    __init = function(self)
+      self.name = "ffmpeg"
+    end,
+    __base = _base_0,
+    __name = "FfmpegBackend",
+    __parent = _parent_0
+  }, {
+    __index = function(cls, name)
+      local val = rawget(_base_0, name)
+      if val == nil then
+        local parent = rawget(cls, "__parent")
+        if parent then
+          return parent[name]
+        end
+      else
+        return val
+      end
+    end,
+    __call = function(cls, ...)
+      local _self_0 = setmetatable({}, _base_0)
+      cls.__init(_self_0, ...)
+      return _self_0
+    end
+  })
+  _base_0.__class = _class_0
+  local self = _class_0
+  local _ = solve
+  if _parent_0.__inherited then
+    _parent_0.__inherited(_parent_0, _class_0)
+  end
+  FfmpegBackend = _class_0
+end
+backends["ffmpeg"] = FfmpegBackend()
 local get_active_tracks
 get_active_tracks = function()
   local accepted = {
@@ -617,241 +1216,125 @@ get_active_tracks = function()
   local active = { }
   for _, track in ipairs(mp.get_property_native("track-list")) do
     if track["selected"] and accepted[track["type"]] then
-      active[#active + 1] = track
+      active[#active + 1] = Track(track["id"], track["ff-index"], track["type"])
     end
   end
   return active
 end
-local get_scale_filters
-get_scale_filters = function()
-  if options.scale_height > 0 then
-    return {
-      "lavfi-scale=-1:" .. tostring(options.scale_height)
-    }
-  end
-  return { }
-end
-local append_property
-append_property = function(out, property_name, option_name)
-  option_name = option_name or property_name
-  local prop = mp.get_property(property_name)
-  if prop and prop ~= "" then
-    return append(out, {
-      "--" .. tostring(option_name) .. "=" .. tostring(prop)
-    })
-  end
-end
-local append_list_options
-append_list_options = function(out, property_name, option_prefix)
-  option_prefix = option_prefix or property_name
-  local prop = mp.get_property_native(property_name)
-  if prop then
-    for _index_0 = 1, #prop do
-      local value = prop[_index_0]
-      append(out, {
-        "--" .. tostring(option_prefix) .. "-append=" .. tostring(value)
-      })
-    end
-  end
-end
-local get_playback_options
-get_playback_options = function()
-  local ret = { }
-  append_property(ret, "sub-ass-override")
-  append_property(ret, "sub-ass-force-style")
-  append_property(ret, "sub-auto")
-  for _, track in ipairs(mp.get_property_native("track-list")) do
-    if track["type"] == "sub" and track["external"] then
-      append(ret, {
-        "--sub-files-append=" .. tostring(track['external-filename'])
-      })
-    end
-  end
-  return ret
-end
-local apply_current_filters
-apply_current_filters = function(filters)
-  local vf = mp.get_property_native("vf")
-  msg.verbose("apply_current_filters: got " .. tostring(#vf) .. " currently applied.")
-  for _index_0 = 1, #vf do
+local get_current_filters
+get_current_filters = function()
+  local current_filters = mp.get_property_native("vf")
+  local filters = { }
+  msg.verbose("apply_current_filters: got " .. tostring(#current_filters) .. " currently applied.")
+  for _index_0 = 1, #current_filters do
     local _continue_0 = false
     repeat
-      local filter = vf[_index_0]
+      local filter = current_filters[_index_0]
       msg.verbose("apply_current_filters: filter name: " .. tostring(filter['name']))
-      if filter["enabled"] == false then
+      if filter.enabled == false then
         _continue_0 = true
         break
       end
-      if filter["name"] == "crop" then
+      if filter.name == "crop" then
         _continue_0 = true
         break
       end
-      local str = filter["name"]
-      local params = filter["params"] or { }
-      for k, v in pairs(params) do
-        str = str .. ":" .. tostring(k) .. "=%" .. tostring(string.len(v)) .. "%" .. tostring(v)
-      end
-      append(filters, {
-        str
-      })
+      filters[#filters + 1] = MpvFilter(filter.name, filter.params)
       _continue_0 = true
     until true
     if not _continue_0 then
       break
     end
   end
+  return filters
 end
 local encode
 encode = function(region, startTime, endTime)
+  local backend = backends[options.encoder]
   local format = formats[options.output_format]
-  local path = mp.get_property("path")
-  if not path then
+  local params = EncodingParameters()
+  params.format = format
+  params.startTime = startTime
+  params.endTime = endTime
+  params.inputPath = mp.get_property("path")
+  if not params.inputPath then
     message("No file is being played")
     return 
   end
-  local is_stream = not file_exists(path)
-  local command = {
-    "mpv",
-    path,
-    "--start=" .. seconds_to_time_string(startTime, false, true),
-    "--end=" .. seconds_to_time_string(endTime, false, true),
-    "--ovc=" .. tostring(format.videoCodec),
-    "--oac=" .. tostring(format.audioCodec),
-    "--loop-file=no"
-  }
-  local vid = -1
-  local aid = -1
-  local sid = -1
   for _, track in ipairs(get_active_tracks()) do
     local _exp_0 = track["type"]
     if "video" == _exp_0 then
-      vid = track['id']
+      params.videoTrack = track
     elseif "audio" == _exp_0 then
-      aid = track['id']
+      params.audioTrack = track
     elseif "sub" == _exp_0 then
-      sid = track['id']
+      params.subTrack = track
     end
   end
-  append(command, {
-    "--vid=" .. (vid >= 0 and tostring(vid) or "no"),
-    "--aid=" .. (aid >= 0 and tostring(aid) or "no"),
-    "--sid=" .. (sid >= 0 and tostring(sid) or "no")
-  })
-  append(command, get_playback_options())
-  local filters = { }
-  append(filters, format:getPreFilters())
+  if options.scale_height > 0 then
+    params.scale = Point(-1, options.scale_height)
+  end
   if options.apply_current_filters then
-    apply_current_filters(filters)
+    params.mpvFilters = get_current_filters()
   end
   if not region or not region:is_valid() then
     msg.verbose("Invalid/unset region, using fullscreen one.")
-    region = make_fullscreen_region()
+    params.crop = make_fullscreen_region()
+  else
+    params.crop = region
   end
-  append(filters, {
-    "lavfi-crop=" .. tostring(region.w) .. ":" .. tostring(region.h) .. ":" .. tostring(region.x) .. ":" .. tostring(region.y)
-  })
-  append(filters, get_scale_filters())
-  append(filters, format:getPostFilters())
-  for _index_0 = 1, #filters do
-    local f = filters[_index_0]
-    append(command, {
-      "--vf-add=" .. tostring(f)
-    })
-  end
-  append(command, format:getFlags())
-  if options.target_filesize > 0 and format.acceptsBitrate then
+  if options.target_filesize > 0 then
     local dT = endTime - startTime
     if options.strict_filesize_constraint then
       local video_kilobits = options.target_filesize * 8
-      if aid >= 0 then
+      if params.audioTrack ~= nil then
         video_kilobits = video_kilobits - dT * options.strict_audio_bitrate
-        append(command, {
-          "--oacopts-add=b=" .. tostring(options.strict_audio_bitrate) .. "k"
-        })
+        params.audioBitrate = options.strict_audio_bitrate
       end
       video_kilobits = video_kilobits * options.strict_bitrate_multiplier
       local bitrate = math.floor(video_kilobits / dT)
-      append(command, {
-        "--ovcopts-add=b=" .. tostring(bitrate) .. "k",
-        "--ovcopts-add=minrate=" .. tostring(bitrate) .. "k",
-        "--ovcopts-add=maxrate=" .. tostring(bitrate) .. "k"
-      })
+      params.bitrate = bitrate
+      params.minBitrate = bitrate
+      params.maxBitrate = bitrate
     else
       local bitrate = math.floor(options.target_filesize * 8 / dT)
-      append(command, {
-        "--ovcopts-add=b=" .. tostring(bitrate) .. "k"
-      })
+      params.bitrate = bitrate
     end
   end
   for token in string.gmatch(options.additional_flags, "[^%s]+") do
-    command[#command + 1] = token
+    params.flags[#params.flags + 1] = token
   end
   if not options.strict_filesize_constraint then
     for token in string.gmatch(options.non_strict_additional_flags, "[^%s]+") do
-      command[#command + 1] = token
+      params.flags[#params.flags + 1] = token
     end
   end
-  if options.twopass and format.supportsTwopass and not is_stream then
-    local first_pass_cmdline
-    do
-      local _accum_0 = { }
-      local _len_0 = 1
-      for _index_0 = 1, #command do
-        local arg = command[_index_0]
-        _accum_0[_len_0] = arg
-        _len_0 = _len_0 + 1
-      end
-      first_pass_cmdline = _accum_0
-    end
-    append(first_pass_cmdline, {
-      "--ovcopts-add=flags=+pass1",
-      "-of=" .. tostring(format.outputExtension),
-      "-o=" .. tostring(get_null_path())
-    })
-    message("Starting first pass...")
-    msg.verbose("First-pass command line: ", table.concat(first_pass_cmdline, " "))
-    local res = run_subprocess({
-      args = first_pass_cmdline,
-      cancellable = false
-    })
-    if not res then
-      message("First pass failed! Check the logs for details.")
-      return 
-    end
-    append(command, {
-      "--ovcopts-add=flags=+pass2"
-    })
-  end
+  local is_stream = not file_exists(params.inputPath)
+  params.twopass = options.twopass and not is_stream
   local dir = ""
-  if is_stream then
+  if options.output_directory ~= "" then
+    dir = options.output_directory
+  elseif is_stream then
     dir = parse_directory("~")
   else
     local _
-    dir, _ = utils.split_path(path)
-  end
-  if options.output_directory ~= "" then
-    dir = parse_directory(options.output_directory)
+    dir, _ = utils.split_path(params.inputPath)
   end
   local formatted_filename = format_filename(startTime, endTime, format)
   local out_path = utils.join_path(dir, formatted_filename)
-  append(command, {
-    "-o=" .. tostring(out_path)
-  })
-  msg.info("Encoding to", out_path)
-  msg.verbose("Command line:", table.concat(command, " "))
+  params.outputPath = out_path
   if options.run_detached then
-    message("Started encode, process was detached.")
-    return utils.subprocess_detached({
-      args = command
-    })
-  else
-    message("Started encode...")
-    local res = run_subprocess({
-      args = command,
-      cancellable = false
-    })
+    local res = backend:encodeDetached(params)
     if res then
-      return message("Encoded successfully! Saved to\\N" .. tostring(bold(out_path)))
+      return message("Started encode, process was detached. (" .. tostring(backend.name) .. ")")
+    else
+      return message("Encode failed! Couldn't start encode. Check the logs for details.")
+    end
+  else
+    message("Started encode... (" .. tostring(backend.name) .. ")")
+    local res = backend:encode(params)
+    if res then
+      return message("Encoded successfully! Saved to\\N" .. tostring(bold(res)))
     else
       return message("Encode failed! Check the logs for details.")
     end
@@ -1363,7 +1846,8 @@ do
       local formatIds = {
         "webm-vp8",
         "webm-vp9",
-        "raw"
+        "raw",
+        "hevc-h264"
       }
       local formatOpts = {
         possibleValues = (function()

--- a/src/backends/base.moon
+++ b/src/backends/base.moon
@@ -4,22 +4,16 @@ class Backend
 	new: =>
 		@name = "No backend"
 
-	encode: (params) =>
+	encode: (params, detached) =>
 		msg.verbose("Building command from params: ", utils.to_string(params))
 		command = self\buildCommand(params)
 		if command
 			msg.info("Encoding to", params.outputPath)
 			msg.verbose("Command line:", table.concat(command, " "))
+			if detached
+				utils.subprocess_detached({args: command})
+				return true
 			return run_subprocess({args: command, cancellable: false})
-		return false
-
-	encodeDetached: (params) =>
-		command = self\buildCommand(params)
-		if command
-			msg.info("Encoding to", params.outputPath)
-			msg.verbose("Command line:", table.concat(command, " "))
-			utils.subprocess_detached({args: command})
-			return true
 		return false
 
 	buildCommand: (params) => nil

--- a/src/backends/base.moon
+++ b/src/backends/base.moon
@@ -1,0 +1,25 @@
+backends = {}
+
+class Backend
+	new: =>
+		@name = "No backend"
+
+	encode: (params) =>
+		msg.verbose("Building command from params: ", utils.to_string(params))
+		command = self\buildCommand(params)
+		if command
+			msg.info("Encoding to", params.outputPath)
+			msg.verbose("Command line:", table.concat(command, " "))
+			return run_subprocess({args: command, cancellable: false})
+		return false
+
+	encodeDetached: (params) =>
+		command = self\buildCommand(params)
+		if command
+			msg.info("Encoding to", params.outputPath)
+			msg.verbose("Command line:", table.concat(command, " "))
+			utils.subprocess_detached({args: command})
+			return true
+		return false
+
+	buildCommand: (params) => nil

--- a/src/backends/ffmpeg.moon
+++ b/src/backends/ffmpeg.moon
@@ -1,0 +1,110 @@
+class FfmpegBackend extends Backend
+	new: =>
+		@name = "ffmpeg"
+
+	solve
+
+	-- Turn `MpvFilter`s into command line options.
+	solveFilters: (filters) =>
+		solved = {}
+		for filter in *filters
+			if not filter.lavfiCompat
+				continue
+			str = filter.name .. "="
+			for k, v in pairs filter.params
+				str ..= "#{v}:"
+			solved[#solved+1] = string.sub(str, 0, string.len(str) - 1)
+		return solved
+
+	buildCommand: (params) =>
+		format = params.format
+
+		-- Build the base command.
+		command = {
+			options.encoder_location,
+			"-y",
+			"-ss", seconds_to_time_string(params.startTime, false, true),
+			"-i", params.inputPath,
+			"-t", tostring(params.endTime - params.startTime)
+		}
+
+		-- Append our track mappings.
+		if params.videoTrack ~= nil and params.videoTrack.index ~= nil
+			append(command, {
+				"-map", "0:" .. tostring(params.videoTrack.index)
+			})
+		if params.audioTrack ~= nil and params.audioTrack.index ~= nil
+			append(command, {
+				"-map", "0:" .. tostring(params.audioTrack.index)
+			})
+		if params.subTrack ~= nil and params.subTrack.index ~= nil
+			append(command, {
+				"-map", "0:" .. tostring(params.subTrack.index)
+			})
+
+		-- Append our video/audio codecs.
+		append(command, {
+			"-c:v", "#{format.videoCodec}", "-c:a", "#{format.audioCodec}"
+		})
+
+		-- Append filters: Prefilters from the format, raw filters from the parameters, cropping
+		-- and scaling filters, and postfilters from the format.
+		-- Begin by solving them from our parameters.
+		filters = {}
+		append(filters, self\solveFilters(format\getPreFilters self))
+		append(filters, self\solveFilters(params.mpvFilters))
+		if params.crop
+			filters[#filters+1] = "crop=#{params.crop.w}:#{params.crop.h}:#{params.crop.x}:#{params.crop.y}"
+		if params.scale
+			filters[#filters+1] = "scale=#{params.scale.x}:#{params.scale.y}"
+		append(filters, self\solveFilters(format\getPostFilters self))
+		-- Then append them to the command.
+		append(command, {
+			"-vf", table.concat(filters, ",")
+		})
+
+		-- Append any extra flags the format wants.
+		append(command, format\getFlags self)
+
+		-- Append bitrate options.
+		if format.acceptsBitrate
+			if params.audioBitrate ~= 0
+				append(command, {"-b:a", "#{params.audioBitrate}K"})
+			if params.bitrate ~= 0
+				append(command, {"-b:v", "#{params.bitrate}K"})
+			if params.minBitrate ~= 0
+				append(command, {"-minrate", "#{params.minBitrate}K"})
+			if params.maxBitrate ~= 0
+				append(command, {"-maxrate", "#{params.maxBitrate}K"})
+
+		-- Append user-passed flags.
+		for flag in *params.flags
+			command[#command+1] = flag
+
+		-- If two-pass is go, do the first pass now with the current command. Note: This
+		-- ignores the user option to run the encoding process detached (for the first pass).
+		if params.twopass and format.supportsTwopass
+			-- copy the commandline
+			first_pass_cmdline = [arg for arg in *command]
+			append(first_pass_cmdline, {
+				"-pass", "1",
+				get_null_path!
+			})
+			message("Starting first pass...")
+			msg.verbose("First-pass command line: ", table.concat(first_pass_cmdline, " "))
+			res = run_subprocess({args: first_pass_cmdline, cancellable: false})
+			if not res
+				message("First pass failed! Check the logs for details.")
+				return nil
+			-- set the second pass flag on the final encode command
+			append(command, {
+				"-pass", "2"
+			})
+
+		-- Append the output path. It's assumed elsewhere that this parameter IS the output
+		-- path. Not wise to modify it here!
+		append(command, {params.outputPath})
+
+		return command
+
+backends["ffmpeg"] = FfmpegBackend!

--- a/src/backends/ffmpeg.moon
+++ b/src/backends/ffmpeg.moon
@@ -21,7 +21,7 @@ class FfmpegBackend extends Backend
 
 		-- Build the base command.
 		command = {
-			options.encoder_location,
+			get_backend_location!,
 			"-y",
 			"-ss", seconds_to_time_string(params.startTime, false, true),
 			"-i", params.inputPath,

--- a/src/backends/ffmpeg.moon
+++ b/src/backends/ffmpeg.moon
@@ -2,8 +2,6 @@ class FfmpegBackend extends Backend
 	new: =>
 		@name = "ffmpeg"
 
-	solve
-
 	-- Turn `MpvFilter`s into command line options.
 	solveFilters: (filters) =>
 		solved = {}

--- a/src/backends/ffmpeg.moon
+++ b/src/backends/ffmpeg.moon
@@ -9,8 +9,20 @@ class FfmpegBackend extends Backend
 			if not filter.lavfiCompat
 				continue
 			str = filter.name .. "="
+			ordered_params = {}
+			highest_n = 0
 			for k, v in pairs filter.params
-				str ..= "#{v}:"
+				-- @n keys dictate the order of keyless params. Sort them here.
+				param_n = tonumber(string.match(k, "^@(%d+)$"))
+				if param_n ~= nil
+					ordered_params[param_n] = v
+					if param_n > highest_n
+						highest_n = param_n
+				else
+					str ..= "#{k}=#{v}:"
+			for i = 0, highest_n
+				if ordered_params[i] ~= nil
+					str ..= "#{ordered_params[i]}:"
 			solved[#solved+1] = string.sub(str, 0, string.len(str) - 1)
 		return solved
 

--- a/src/backends/mpv.moon
+++ b/src/backends/mpv.moon
@@ -41,7 +41,7 @@ class MpvBackend extends Backend
 
 		-- Build the base command.
 		command = {
-			options.encoder_location, params.inputPath,
+			get_backend_location!, params.inputPath,
 			"--start=" .. seconds_to_time_string(params.startTime, false, true),
 			"--end=" .. seconds_to_time_string(params.endTime, false, true),
 			"--ovc=#{format.videoCodec}", "--oac=#{format.audioCodec}",

--- a/src/backends/mpv.moon
+++ b/src/backends/mpv.moon
@@ -1,0 +1,124 @@
+class MpvBackend extends Backend
+	new: =>
+		@name = "mpv"
+
+	appendProperty: (out, property_name, option_name) =>
+		option_name = option_name or property_name
+		prop = mp.get_property(property_name)
+		if prop and prop != ""
+			append(out, {"--#{option_name}=#{prop}"})
+
+	getPlaybackOptions: =>
+		ret = {}
+		self\appendProperty(ret, "sub-ass-override")
+		self\appendProperty(ret, "sub-ass-force-style")
+		self\appendProperty(ret, "sub-auto")
+
+		-- tracks added manually (eg. drag-and-drop) won't appear on sub-files, so we
+		-- read them from the track-list.
+		for _, track in ipairs mp.get_property_native("track-list")
+			if track["type"] == "sub" and track["external"]
+				append(ret, {"--sub-files-append=#{track['external-filename']}"})
+
+		return ret
+
+	-- Turn `MpvFilter`s into command line options.
+	solveFilters: (filters) =>
+		solved = {}
+		for filter in *filters
+			str = filter.lavfiCompat and "lavfi-" or ""
+			str ..= filter.name .. "="
+			for k, v in pairs filter.params
+				if tonumber(k) == nil
+					str ..= "#{k}=%#{string.len(v)}%#{v}:"
+				else
+					str ..= "#{v}:"
+			solved[#solved+1] = string.sub(str, 0, string.len(str) - 1)
+		return solved
+
+	buildCommand: (params) =>
+		format = params.format
+
+		-- Build the base command.
+		command = {
+			options.encoder_location, params.inputPath,
+			"--start=" .. seconds_to_time_string(params.startTime, false, true),
+			"--end=" .. seconds_to_time_string(params.endTime, false, true),
+			"--ovc=#{format.videoCodec}", "--oac=#{format.audioCodec}",
+			-- When loop-file=inf, the encode won't end. Set this to override.
+			"--loop-file=no"
+		}
+
+		-- Append video/audio/sub track options.
+		append(command, {
+			"--vid=" .. (params.videoTrack ~= nil and tostring(params.videoTrack.id) or "no"),
+			"--aid=" .. (params.audioTrack ~= nil and tostring(params.audioTrack.id) or "no"),
+			"--sid=" .. (params.subTrackId ~= nil and tostring(params.subTrack.id) or "no")
+		})
+
+		-- Append mpv exclusive options based on playback to have the encoding match it
+		-- as much as possible.
+		append(command, self\getPlaybackOptions!)
+
+		-- Append filters: Prefilters from the format, raw filters from the parameters, cropping
+		-- and scaling filters, and postfilters from the format.
+		-- Begin by solving them from our parameters.
+		filters = {}
+		append(filters, self\solveFilters(format\getPreFilters self))
+		append(filters, self\solveFilters(params.mpvFilters))
+		if params.crop
+			filters[#filters+1] = "lavfi-crop=#{params.crop.w}:#{params.crop.h}:#{params.crop.x}:#{params.crop.y}"
+		if params.scale
+			filters[#filters+1] = "lavfi-scale=#{params.scale.x}:#{params.scale.y}"
+		append(filters, self\solveFilters(format\getPostFilters self))
+		-- Then append them to the command.
+		for f in *filters
+			command[#command+1] = "--vf-add=#{f}"
+
+		-- Append any extra flags the format wants.
+		append(command, format\getFlags self)
+
+		-- Append bitrate options.
+		if format.acceptsBitrate
+			if params.audioBitrate ~= 0
+				command[#command+1] = "--oacopts-add=b=#{params.audioBitrate}k"
+			if params.bitrate ~= 0
+				command[#command+1] = "--ovcopts-add=b=#{params.bitrate}k"
+			if params.minBitrate ~= 0
+				command[#command+1] = "--ovcopts-add=minrate=#{params.bitrate}k"
+			if params.maxBitrate ~= 0
+				command[#command+1] = "--ovcopts-add=maxrate=#{params.bitrate}k"
+
+		-- Append user-passed flags.
+		for flag in *params.flags
+			command[#command+1] = flag
+
+		-- If two-pass is go, do the first pass now with the current command. Note: This
+		-- ignores the user option to run the encoding process detached (for the first pass).
+		-- (Kind of shit to do this in a method called "buildCommand" but eh)
+		if params.twopass and format.supportsTwopass
+			-- copy the commandline
+			first_pass_cmdline = [arg for arg in *command]
+			append(first_pass_cmdline, {
+				"--ovcopts-add=flags=+pass1",
+				"-of=#{format.outputExtension}",
+				"-o=#{get_null_path!}"
+			})
+			message("Starting first pass...")
+			msg.verbose("First-pass command line: ", table.concat(first_pass_cmdline, " "))
+			res = run_subprocess({args: first_pass_cmdline, cancellable: false})
+			if not res
+				message("First pass failed! Check the logs for details.")
+				return nil
+			-- set the second pass flag on the final encode command
+			append(command, {
+				"--ovcopts-add=flags=+pass2"
+			})
+
+		-- Append the output path. It's assumed elsewhere that this parameter IS the output
+		-- path. Not wise to modify it here!
+		append(command, {"-o=#{params.outputPath}"})
+
+		return command
+
+backends["mpv"] = MpvBackend!

--- a/src/backends/mpv.moon
+++ b/src/backends/mpv.moon
@@ -29,10 +29,7 @@ class MpvBackend extends Backend
 			str = filter.lavfiCompat and "lavfi-" or ""
 			str ..= filter.name .. "="
 			for k, v in pairs filter.params
-				if tonumber(k) == nil
-					str ..= "#{k}=%#{string.len(v)}%#{v}:"
-				else
-					str ..= "#{v}:"
+				str ..= "#{k}=%#{string.len(v)}%#{v}:"
 			solved[#solved+1] = string.sub(str, 0, string.len(str) - 1)
 		return solved
 

--- a/src/encode.moon
+++ b/src/encode.moon
@@ -1,103 +1,3 @@
--- Represents a video/audio/subtitle track.
-class Track
-	new: (id, index, type) =>
-		@id = id
-		@index = index
-		@type = type
-
--- Represents an mpv video/audio filter.
-class MpvFilter
-	new: (name, params={}) =>
-		-- Note: You don't need to specify the lavfi- prefix to
-		-- use valid lavfi filters, it's only used as a disambiguation
-		-- against mpv's builtin filters. So not all compatible filters
-		-- will be caught here.
-		if string.sub(name,1,6)=="lavfi-" then
-			@name = string.sub(name,7,string.len(name))
-			@lavfiCompat = true
-		else
-			@name = name
-			@lavfiCompat = false
-		@params = params
-
-class EncodingParameters
-	new: =>
-		-- {Format}
-		-- The format to encode in.
-		@format = nil
-
-		-- {string}
-		-- The full path to the input stream.
-		@inputPath = nil
-
-		-- {string}
-		-- The output path the encoding will be written to.
-		@outputPath = nil
-
-		-- {number}
-		-- The start time in milliseconds.
-		@startTime = 0
-
-		-- {number}
-		-- The end time in milliseconds.
-		@endTime = 0
-
-		-- {Region}
-		-- A region specifying how to crop the video. `nil`
-		-- for no cropping.
-		@crop = nil
-
-		-- {Point}
-		-- A point specifying how the video should be
-		-- scaled. `nil` means no scaling and `-1` for
-		-- either x or y means aspect ratio should be
-		-- maintained.
-		@scale = nil
-
-		-- {Track}
-		-- The video track to include. `nil` for no video.
-		@videoTrack = nil
-
-		-- {Track}
-		-- The audio track to include. `nil` for no audio.
-		@audioTrack = nil
-
-		-- {Track}
-		-- The subtitle track to include. `nil` for no
-		-- subtitles.
-		@subTrack = nil
-
-		-- {number}
-		-- The target bitrate in kB. `0` to disable.
-		@bitrate = 0
-
-		-- {number}
-		-- The minimum allowed bitrate in kB. `0` to
-		-- disable.
-		@minBitrate = 0
-
-		-- {number}
-		-- The maximum allowed bitrate in kB. `0` to
-		-- disable.
-		@maxBitrate = 0
-
-		-- {number}
-		-- The target audio bitrate in kB. `0` to disable.
-		@audioBitrate = 0
-
-		-- {boolean}
-		-- Whether or not to use two-pass encoding.
-		@twopass = false
-
-		-- {MpvFilter[]}
-		-- A table of additional mpv filters that should be
-		-- applied to the encoding, or attempted to.
-		@mpvFilters = {}
-
-		-- {Table}
-		-- Additional (backend-specific) flags.
-		@flags = {}
-
 get_active_tracks = ->
 	accepted =
 		video: true
@@ -127,7 +27,7 @@ get_current_filters = ->
 	return filters
 
 encode = (region, startTime, endTime) ->
-	backend = backends[options.encoder]
+	backend = backends[options.backend]
 	format = formats[options.output_format]
 
 	params = EncodingParameters!
@@ -216,6 +116,6 @@ encode = (region, startTime, endTime) ->
 		message("Started encode... (#{backend.name})")
 		res = backend\encode(params)
 		if res
-			message("Encoded successfully! Saved to\\N#{bold(res)}")
+			message("Encoded successfully! Saved to\\N#{bold(params.outputPath)}")
 		else
 			message("Encode failed! Check the logs for details.")

--- a/src/encode.moon
+++ b/src/encode.moon
@@ -107,14 +107,14 @@ encode = (region, startTime, endTime) ->
 	params.outputPath = out_path
 
 	if options.run_detached
-		res = backend\encodeDetached(params)
+		res = backend\encode(params, true)
 		if res
 			message("Started encode, process was detached. (#{backend.name})")
 		else
 			message("Encode failed! Couldn't start encode. Check the logs for details.")
 	else
 		message("Started encode... (#{backend.name})")
-		res = backend\encode(params)
+		res = backend\encode(params, false)
 		if res
 			message("Encoded successfully! Saved to\\N#{bold(params.outputPath)}")
 		else

--- a/src/encode.moon
+++ b/src/encode.moon
@@ -1,3 +1,103 @@
+-- Represents a video/audio/subtitle track.
+class Track
+	new: (id, index, type) =>
+		@id = id
+		@index = index
+		@type = type
+
+-- Represents an mpv video/audio filter.
+class MpvFilter
+	new: (name, params={}) =>
+		-- Note: You don't need to specify the lavfi- prefix to
+		-- use valid lavfi filters, it's only used as a disambiguation
+		-- against mpv's builtin filters. So not all compatible filters
+		-- will be caught here.
+		if string.sub(name,1,6)=="lavfi-" then
+			@name = string.sub(name,7,string.len(name))
+			@lavfiCompat = true
+		else
+			@name = name
+			@lavfiCompat = false
+		@params = params
+
+class EncodingParameters
+	new: =>
+		-- {Format}
+		-- The format to encode in.
+		@format = nil
+
+		-- {string}
+		-- The full path to the input stream.
+		@inputPath = nil
+
+		-- {string}
+		-- The output path the encoding will be written to.
+		@outputPath = nil
+
+		-- {number}
+		-- The start time in milliseconds.
+		@startTime = 0
+
+		-- {number}
+		-- The end time in milliseconds.
+		@endTime = 0
+
+		-- {Region}
+		-- A region specifying how to crop the video. `nil`
+		-- for no cropping.
+		@crop = nil
+
+		-- {Point}
+		-- A point specifying how the video should be
+		-- scaled. `nil` means no scaling and `-1` for
+		-- either x or y means aspect ratio should be
+		-- maintained.
+		@scale = nil
+
+		-- {Track}
+		-- The video track to include. `nil` for no video.
+		@videoTrack = nil
+
+		-- {Track}
+		-- The audio track to include. `nil` for no audio.
+		@audioTrack = nil
+
+		-- {Track}
+		-- The subtitle track to include. `nil` for no
+		-- subtitles.
+		@subTrack = nil
+
+		-- {number}
+		-- The target bitrate in kB. `0` to disable.
+		@bitrate = 0
+
+		-- {number}
+		-- The minimum allowed bitrate in kB. `0` to
+		-- disable.
+		@minBitrate = 0
+
+		-- {number}
+		-- The maximum allowed bitrate in kB. `0` to
+		-- disable.
+		@maxBitrate = 0
+
+		-- {number}
+		-- The target audio bitrate in kB. `0` to disable.
+		@audioBitrate = 0
+
+		-- {boolean}
+		-- Whether or not to use two-pass encoding.
+		@twopass = false
+
+		-- {MpvFilter[]}
+		-- A table of additional mpv filters that should be
+		-- applied to the encoding, or attempted to.
+		@mpvFilters = {}
+
+		-- {Table}
+		-- Additional (backend-specific) flags.
+		@flags = {}
+
 get_active_tracks = ->
 	accepted =
 		video: true
@@ -6,203 +106,116 @@ get_active_tracks = ->
 	active = {}
 	for _, track in ipairs mp.get_property_native("track-list")
 		if track["selected"] and accepted[track["type"]]
-			active[#active + 1] = track
+			active[#active + 1] = Track(track["id"], track["ff-index"], track["type"])
 	return active
 
-get_scale_filters = ->
-	if options.scale_height > 0
-		return {"lavfi-scale=-1:#{options.scale_height}"}
-	return {}
-
-append_property = (out, property_name, option_name) ->
-	option_name = option_name or property_name
-	prop = mp.get_property(property_name)
-	if prop and prop != ""
-		append(out, {"--#{option_name}=#{prop}"})
-
--- Reads a mpv "list option" property and set the corresponding command line flags (as specified on the manual)
--- option_prefix is optional, will be set to property_name if empty
-append_list_options = (out, property_name, option_prefix) ->
-	option_prefix = option_prefix or property_name
-	prop = mp.get_property_native(property_name)
-	if prop
-		for value in *prop
-			append(out, {"--#{option_prefix}-append=#{value}"})
-
--- Get the current playback options, trying to match how the video is being played.
-get_playback_options = ->
-	ret = {}
-	append_property(ret, "sub-ass-override")
-	append_property(ret, "sub-ass-force-style")
-	append_property(ret, "sub-auto")
-
-	-- tracks added manually (eg. drag-and-drop) won't appear on sub-files, so we
-	-- read them from the track-list.
-	for _, track in ipairs mp.get_property_native("track-list")
-		if track["type"] == "sub" and track["external"]
-			append(ret, {"--sub-files-append=#{track['external-filename']}"})
-
-	return ret
-
-apply_current_filters = (filters) ->
-	vf = mp.get_property_native("vf")
-	msg.verbose("apply_current_filters: got #{#vf} currently applied.")
-	for filter in *vf
+get_current_filters = ->
+	current_filters = mp.get_property_native("vf")
+	filters = {}
+	msg.verbose("apply_current_filters: got #{#current_filters} currently applied.")
+	for filter in *current_filters
 		msg.verbose("apply_current_filters: filter name: #{filter['name']}")
 		-- This might seem like a redundant check (if not filter["enabled"] would achieve the same result),
 		-- but the enabled field isn't guaranteed to exist... and if it's nil, "not filter['enabled']"
 		-- would achieve a different outcome.
-		if filter["enabled"] == false
+		if filter.enabled == false
 			continue
 		-- We apply our own crop filter.
-		if filter["name"] == "crop"
+		if filter.name == "crop"
 			continue
-		str = filter["name"]
-		params = filter["params"] or {}
-		for k, v in pairs params
-			str = str .. ":#{k}=%#{string.len(v)}%#{v}"
-		append(filters, {str})
+		filters[#filters+1] = MpvFilter(filter.name, filter.params)
+	return filters
 
 encode = (region, startTime, endTime) ->
+	backend = backends[options.encoder]
 	format = formats[options.output_format]
 
-	path = mp.get_property("path")
-	if not path
+	params = EncodingParameters!
+	params.format = format
+	params.startTime = startTime
+	params.endTime = endTime
+
+	params.inputPath = mp.get_property("path")
+	if not params.inputPath
 		message("No file is being played")
 		return
 
-	is_stream = not file_exists(path)
-
-	command = {
-		"mpv", path,
-		"--start=" .. seconds_to_time_string(startTime, false, true),
-		"--end=" .. seconds_to_time_string(endTime, false, true),
-		"--ovc=#{format.videoCodec}", "--oac=#{format.audioCodec}",
-		-- When loop-file=inf, the encode won't end. Set this to override.
-		"--loop-file=no"
-	}
-
-	vid = -1
-	aid = -1
-	sid = -1
 	for _, track in ipairs get_active_tracks!
 		switch track["type"]
 			when "video"
-				vid = track['id']
+				params.videoTrack = track
 			when "audio"
-				aid = track['id']
+				params.audioTrack = track
 			when "sub"
-				sid = track['id']
+				params.subTrack = track
 
-	append(command, {
-		"--vid=" .. (vid >= 0 and tostring(vid) or "no"),
-		"--aid=" .. (aid >= 0 and tostring(aid) or "no"),
-		"--sid=" .. (sid >= 0 and tostring(sid) or "no")
-	})
-
-	append(command, get_playback_options!)
-
-	filters = {}
-	append(filters, format\getPreFilters!)
+	if options.scale_height > 0
+		params.scale = Point(-1, options.scale_height)
 
 	if options.apply_current_filters
-		apply_current_filters(filters)
+		params.mpvFilters = get_current_filters!
 	
 	-- Even if we don't have a set region, the user might have external crops applied.
 	-- Solve this by using a region that covers the entire visible screen.
 	if not region or not region\is_valid!
 		msg.verbose("Invalid/unset region, using fullscreen one.")
-		region = make_fullscreen_region!
+		params.crop = make_fullscreen_region!
+	else
+		params.crop = region
 
-	append(filters, {"lavfi-crop=#{region.w}:#{region.h}:#{region.x}:#{region.y}"})
-
-	append(filters, get_scale_filters!)
-
-	append(filters, format\getPostFilters!)
-
-	for f in *filters
-		append(command, {
-			"--vf-add=#{f}"
-		})
-
-	append(command, format\getFlags!)
-
-	if options.target_filesize > 0 and format.acceptsBitrate
+	if options.target_filesize > 0
 		dT = endTime - startTime
 		if options.strict_filesize_constraint
 			-- Calculate video bitrate, assume audio is constant.
 			video_kilobits = options.target_filesize * 8
-			if aid >= 0 -- compensate for audio
+			if params.audioTrack ~= nil -- compensate for audio
 				video_kilobits = video_kilobits - dT * options.strict_audio_bitrate
-				append(command, {
-					"--oacopts-add=b=#{options.strict_audio_bitrate}k"
-				})
+				params.audioBitrate = options.strict_audio_bitrate
 			video_kilobits *= options.strict_bitrate_multiplier
 			bitrate = math.floor(video_kilobits / dT)
-			append(command, {
-				"--ovcopts-add=b=#{bitrate}k",
-				"--ovcopts-add=minrate=#{bitrate}k",
-				"--ovcopts-add=maxrate=#{bitrate}k",
-			})
+			params.bitrate = bitrate
+			params.minBitrate = bitrate
+			params.maxBitrate = bitrate
 		else
 			-- Loosely set the video bitrate.
 			bitrate = math.floor(options.target_filesize * 8 / dT)
-			append(command, {
-				"--ovcopts-add=b=#{bitrate}k"
-			})
+			params.bitrate = bitrate
 
 	-- split the user-passed settings on whitespace
 	for token in string.gmatch(options.additional_flags, "[^%s]+") do
-		command[#command + 1] = token
+		params.flags[#params.flags + 1] = token
 	
 	if not options.strict_filesize_constraint
 		for token in string.gmatch(options.non_strict_additional_flags, "[^%s]+") do
-			command[#command + 1] = token
+			params.flags[#params.flags + 1] = token
 
-	-- Do the first pass now, as it won't require the output path. I don't think this works on streams.
-	-- Also this will ignore run_detached, at least for the first pass.
-	if options.twopass and format.supportsTwopass and not is_stream
-		-- copy the commandline
-		first_pass_cmdline = [arg for arg in *command]
-		append(first_pass_cmdline, {
-			"--ovcopts-add=flags=+pass1",
-			"-of=#{format.outputExtension}",
-			"-o=#{get_null_path!}"
-		})
-		message("Starting first pass...")
-		msg.verbose("First-pass command line: ", table.concat(first_pass_cmdline, " "))
-		res = run_subprocess({args: first_pass_cmdline, cancellable: false})
-		if not res
-			message("First pass failed! Check the logs for details.")
-			return
-		-- set the second pass flag on the final encode command
-		append(command, {
-			"--ovcopts-add=flags=+pass2"
-		})
+	is_stream = not file_exists(params.inputPath)
+
+	params.twopass = options.twopass and not is_stream
 
 	dir = ""
-	if is_stream
+	if options.output_directory != ""
+		dir = options.output_directory
+	elseif is_stream
 		dir = parse_directory("~")
 	else
-		dir, _ = utils.split_path(path)
-
-	if options.output_directory != ""
-		dir = parse_directory(options.output_directory)
+		dir, _ = utils.split_path(params.inputPath)
 	
 	formatted_filename = format_filename(startTime, endTime, format)
 	out_path = utils.join_path(dir, formatted_filename)
-	append(command, {"-o=#{out_path}"})
 
-	msg.info("Encoding to", out_path)
-	msg.verbose("Command line:", table.concat(command, " "))
+	params.outputPath = out_path
 
 	if options.run_detached
-		message("Started encode, process was detached.")
-		utils.subprocess_detached({args: command})
-	else
-		message("Started encode...")
-		res = run_subprocess({args: command, cancellable: false})
+		res = backend\encodeDetached(params)
 		if res
-			message("Encoded successfully! Saved to\\N#{bold(out_path)}")
+			message("Started encode, process was detached. (#{backend.name})")
+		else
+			message("Encode failed! Couldn't start encode. Check the logs for details.")
+	else
+		message("Started encode... (#{backend.name})")
+		res = backend\encode(params)
+		if res
+			message("Encoded successfully! Saved to\\N#{bold(res)}")
 		else
 			message("Encode failed! Check the logs for details.")

--- a/src/encoding_parameters.moon
+++ b/src/encoding_parameters.moon
@@ -1,0 +1,99 @@
+-- Represents a video/audio/subtitle track.
+class Track
+	new: (id, index, type) =>
+		@id = id
+		@index = index
+		@type = type
+
+-- Represents an mpv video/audio filter.
+class MpvFilter
+	new: (name, params={}) =>
+		-- Note: You don't need to specify the lavfi- prefix to
+		-- use valid lavfi filters, it's only used as a disambiguation
+		-- against mpv's builtin filters. So not all compatible filters
+		-- will be caught here.
+		if string.sub(name,1,6)=="lavfi-" then
+			@name = string.sub(name,7,string.len(name))
+			@lavfiCompat = true
+		else
+			@name = name
+			@lavfiCompat = false
+		@params = params
+
+class EncodingParameters
+	new: =>
+		-- {Format}
+		-- The format to encode in.
+		@format = nil
+
+		-- {string}
+		-- The full path to the input stream.
+		@inputPath = nil
+
+		-- {string}
+		-- The output path the encoding will be written to.
+		@outputPath = nil
+
+		-- {number}
+		-- The start time in milliseconds.
+		@startTime = 0
+
+		-- {number}
+		-- The end time in milliseconds.
+		@endTime = 0
+
+		-- {Region}
+		-- A region specifying how to crop the video. `nil`
+		-- for no cropping.
+		@crop = nil
+
+		-- {Point}
+		-- A point specifying how the video should be
+		-- scaled. `nil` means no scaling and `-1` for
+		-- either x or y means aspect ratio should be
+		-- maintained.
+		@scale = nil
+
+		-- {Track}
+		-- The video track to include. `nil` for no video.
+		@videoTrack = nil
+
+		-- {Track}
+		-- The audio track to include. `nil` for no audio.
+		@audioTrack = nil
+
+		-- {Track}
+		-- The subtitle track to include. `nil` for no
+		-- subtitles.
+		@subTrack = nil
+
+		-- {number}
+		-- The target bitrate in kB. `0` to disable.
+		@bitrate = 0
+
+		-- {number}
+		-- The minimum allowed bitrate in kB. `0` to
+		-- disable.
+		@minBitrate = 0
+
+		-- {number}
+		-- The maximum allowed bitrate in kB. `0` to
+		-- disable.
+		@maxBitrate = 0
+
+		-- {number}
+		-- The target audio bitrate in kB. `0` to disable.
+		@audioBitrate = 0
+
+		-- {boolean}
+		-- Whether or not to use two-pass encoding.
+		@twopass = false
+
+		-- {MpvFilter[]}
+		-- A table of additional mpv filters that should be
+		-- applied to the encoding, or attempted to.
+		@mpvFilters = {}
+
+		-- {Table}
+		-- Additional (backend-specific) flags.
+		@flags = {}

--- a/src/encoding_parameters.moon
+++ b/src/encoding_parameters.moon
@@ -101,6 +101,6 @@ class EncodingParameters
 		-- applied to the encoding, or attempted to.
 		@mpvFilters = {}
 
-		-- {Table}
+		-- {string[]}
 		-- Additional (backend-specific) flags.
 		@flags = {}

--- a/src/encoding_parameters.moon
+++ b/src/encoding_parameters.moon
@@ -7,17 +7,24 @@ class Track
 
 -- Represents an mpv video/audio filter.
 class MpvFilter
+	@isBuiltin: (name) ->
+		-- mpv --vf=help
+		(name == "format" or
+		name == "sub" or
+		name == "convert" or
+		name == "d3d11vpp" or
+		-- mpv --af=help
+		name == "lavcac3enc" or
+		name == "lavrresample" or
+		name == "rubberband" or
+		name == "scaletempo")
+
 	new: (name, params={}) =>
-		-- Note: You don't need to specify the lavfi- prefix to
-		-- use valid lavfi filters, it's only used as a disambiguation
-		-- against mpv's builtin filters. So not all compatible filters
-		-- will be caught here.
 		if string.sub(name,1,6)=="lavfi-" then
 			@name = string.sub(name,7,string.len(name))
-			@lavfiCompat = true
 		else
 			@name = name
-			@lavfiCompat = false
+		@lavfiCompat = not @@isBuiltin name
 		@params = params
 
 class EncodingParameters

--- a/src/encoding_parameters.moon
+++ b/src/encoding_parameters.moon
@@ -20,11 +20,11 @@ class MpvFilter
 		name == "scaletempo")
 
 	new: (name, params={}) =>
+		@lavfiCompat = not @@.isBuiltin(name)
 		if string.sub(name,1,6)=="lavfi-" then
 			@name = string.sub(name,7,string.len(name))
 		else
 			@name = name
-		@lavfiCompat = not @@isBuiltin name
 		@params = params
 
 class EncodingParameters

--- a/src/formats/base.moon
+++ b/src/formats/base.moon
@@ -13,10 +13,10 @@ class Format
 
 	-- Filters that should be applied before the transformations we do (crop, scale)
 	-- Should be a array of ffmpeg filters e.g. {"colormatrix=bt709", "sub"}.
-	getPreFilters: => {}
+	getPreFilters: (backend) => {}
 
 	-- Similar to getPreFilters, but after our transformations.
-	getPostFilters: => {}
+	getPostFilters: (backend) => {}
 
 	-- A list of flags, to be appended to the command line.
-	getFlags: => {}
+	getFlags: (backend) => {}

--- a/src/formats/rawvideo.moon
+++ b/src/formats/rawvideo.moon
@@ -28,9 +28,9 @@ class RawVideo extends Format
 
 	getPostFilters: (backend) =>
 		{
-			MpvFilter("format", {"fmt": "yuv444p16"}),
-			MpvFilter("lavfi-scale", {"in_color_matrix": self\getColorspace!}),
-			MpvFilter("format", {"fmt": "bgr24"})
+			MpvFilter("format", { "fmt": "yuv444p16" }),
+			MpvFilter("lavfi-scale", { "in_color_matrix": self\getColorspace! }),
+			MpvFilter("format", { "fmt": "bgr24" })
 		}
 
 formats["raw"] = RawVideo!

--- a/src/formats/rawvideo.moon
+++ b/src/formats/rawvideo.moon
@@ -26,7 +26,11 @@ class RawVideo extends Format
 				msg.info("Warning, unknown colorspace #{csp} detected, using bt.601.")
 				return "bt601"
 
-	getPostFilters: =>
-		{"format=yuv444p16", "lavfi-scale=in_color_matrix=" .. self\getColorspace!, "format=bgr24"}
+	getPostFilters: (backend) =>
+		{
+			MpvFilter("format", {"yuv444p16"}),
+			MpvFilter("lavfi-scale", {"in_color_matrix": self\getColorspace!}),
+			MpvFilter("format", {"bgr24"})
+		}
 
 formats["raw"] = RawVideo!

--- a/src/formats/rawvideo.moon
+++ b/src/formats/rawvideo.moon
@@ -28,9 +28,9 @@ class RawVideo extends Format
 
 	getPostFilters: (backend) =>
 		{
-			MpvFilter("format", {"yuv444p16"}),
+			MpvFilter("format", {"fmt": "yuv444p16"}),
 			MpvFilter("lavfi-scale", {"in_color_matrix": self\getColorspace!}),
-			MpvFilter("format", {"bgr24"})
+			MpvFilter("format", {"fmt": "bgr24"})
 		}
 
 formats["raw"] = RawVideo!

--- a/src/formats/webm.moon
+++ b/src/formats/webm.moon
@@ -7,7 +7,7 @@ class WebmVP8 extends Format
 		@outputExtension = "webm"
 		@acceptsBitrate = true
 
-	getPreFilters: =>
+	getPreFilters: (backend) =>
 		-- colormatrix filter
 		colormatrixFilter =
 			"bt.709": "bt709"
@@ -19,14 +19,16 @@ class WebmVP8 extends Format
 		colormatrix = mp.get_property_native("video-params/colormatrix")
 		if colormatrixFilter[colormatrix]
 			append(ret, {
-				"lavfi-colormatrix=#{colormatrixFilter[colormatrix]}:bt601"
+				MpvFilter("lavfi-colormatrix", {"@0": "#{colormatrixFilter[colormatrix]}", "@1": "bt601"})
 			})
 		return ret
 
-	getFlags: =>
-		{
-			"--ovcopts-add=threads=#{options.libvpx_threads}"
-		}
+	getFlags: (backend) =>
+		switch backend.name
+			when "mpv"
+				return {"--ovcopts-add=threads=#{options.libvpx_threads}"}
+			when "ffmpeg"
+				return {"-threads", options.libvpx_threads}
 
 formats["webm-vp8"] = WebmVP8!
 
@@ -39,9 +41,11 @@ class WebmVP9 extends Format
 		@outputExtension = "webm"
 		@acceptsBitrate = true
 
-	getFlags: =>
-		{
-			"--ovcopts-add=threads=#{options.libvpx_threads}"
-		}
+	getFlags: (backend) =>
+		switch backend.name
+			when "mpv"
+				return {"--ovcopts-add=threads=#{options.libvpx_threads}"}
+			when "ffmpeg"
+				return {"-threads", options.libvpx_threads}
 
 formats["webm-vp9"] = WebmVP9!

--- a/src/formats/webm.moon
+++ b/src/formats/webm.moon
@@ -19,7 +19,9 @@ class WebmVP8 extends Format
 		colormatrix = mp.get_property_native("video-params/colormatrix")
 		if colormatrixFilter[colormatrix]
 			append(ret, {
-				MpvFilter("lavfi-colormatrix", {"@0": "#{colormatrixFilter[colormatrix]}", "@1": "bt601"})
+				MpvFilter("lavfi-colormatrix",
+					"@0": colormatrixFilter[colormatrix],
+					"@1": "bt601")
 			})
 		return ret
 

--- a/src/options.moon
+++ b/src/options.moon
@@ -29,6 +29,10 @@ options =
 	-- Currently we have webm-vp8 (libvpx/libvorbis), webm-vp9 (libvpx-vp9/libvorbis)
 	-- and raw (rawvideo/pcm_s16le).
 	output_format: "webm-vp8"
+	-- The encoding backend to use. Currently supports mpv and ffmpeg.
+	backend: "mpv"
+	-- Location to the backend executable. Leave blank to have this fall back on the backend option.
+	backend_location: ""
 	twopass: false
 	-- If set, applies the video filters currently used on the playback to the encode.
 	apply_current_filters: true

--- a/src/util.moon
+++ b/src/util.moon
@@ -94,3 +94,8 @@ calculate_scale_factor = () ->
 	baseResY = 720
 	osd_w, osd_h = mp.get_osd_size()
 	return osd_h / baseResY
+
+get_backend_location = ->
+	if options.backend_location
+		return options.backend_location
+	return options.backend

--- a/src/util.moon
+++ b/src/util.moon
@@ -96,6 +96,6 @@ calculate_scale_factor = () ->
 	return osd_h / baseResY
 
 get_backend_location = ->
-	if options.backend_location
-		return options.backend_location
-	return options.backend
+	if not options.backend_location or string.len(options.backend_location) == 0
+		return options.backend
+	return options.backend_location

--- a/src/video_to_screen.moon
+++ b/src/video_to_screen.moon
@@ -122,12 +122,14 @@ clamp_point = (top_left, point, bottom_right) ->
 		y: clamp(top_left.y, point.y, bottom_right.y)
 	}
 
--- Stores a point in the video, relative to the source resolution.
-class VideoPoint
-	new: =>
-		@x = -1
-		@y = -1
+-- A point with -1 defaults.
+class Point
+	new: (x=-1, y=-1) =>
+		@x = x
+		@y = y
 
+-- Stores a point in the video, relative to the source resolution.
+class VideoPoint extends Point
 	set_from_screen: (sx, sy) =>
 		d = get_video_dimensions!
 		point = clamp_point(d.top_left, {x: sx, y: sy}, d.bottom_right)


### PR DESCRIPTION
Hey, for personal reasons I wanted to be able to use ffmpeg with this script, so I changed the way encoding is done a bit. This ended up being more massive than I thought, so I figured I'd open this pull request if you're interested, but I understand if it's out of scope.

Outline of changes:
- [`encode.moon`](https://github.com/sides/mpv-webm/blob/master/src/encode.moon) now doesn't build a command to be executed, but instead builds an instance of [`EncodingParameters`](https://github.com/sides/mpv-webm/blob/master/src/encoding_parameters.moon) which are passed to a backend (mpv or ffmpeg).
- [`webm.moon`, `rawvideo.moon`, `formats/base.moon`](https://github.com/sides/mpv-webm/tree/master/src/formats):
  - Now receive a backend instance in their `getX` methods.
  - No longer return raw command line options in their `getXFilters` methods, but instead return an array of `MpvFilter` (which is up to backend discretion to resolve).
- [`backends/`](https://github.com/sides/mpv-webm/tree/master/src/backends) dir was added with ffmpeg and mpv. These create their respective commands with varying support. mpv should be producing the same commands as it was before these changes.
- [`options.moon`](https://github.com/sides/mpv-webm/blob/master/src/options.moon) now has `backend` and `backend_location` options.

Some potential benefits from this:
- Add a format for ffmpeg's stream copy (`-c copy`). This would need a few more changes, particularly in how much control formats have.
- Add an "auto" backend that selects the best one for the current options and playback (so, if you'd select the stream copy format it would select ffmpeg since mpv doesn't have that - if you've enabled ffmpeg in your options).
- Other than that, this was just done for personal tastes.